### PR TITLE
feat: REST API Endpoints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 ## [Unreleased]
 
 ### Added
+- REST API CRUD endpoints for trend items (GET /api/items, POST /api/items, PUT /api/items/{id}, DELETE /api/items/{id})
+- Pydantic schemas for request/response validation (TrendCreate, TrendUpdate, TrendResponse, TrendListResponse)
+- Pagination support for GET /api/items endpoint (skip and limit parameters)
+- Comprehensive API tests for all CRUD operations
 - Initial project scaffolding for CodeScale Research Radar
 - SAPUI5 frontend structure with Component.js, manifest.json, and routing
 - Base views (App.view.xml, Main.view.xml) with i18n support

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -3,6 +3,13 @@
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 
+from .database import engine
+from .models import Base
+from .routers import items
+
+# Create database tables
+Base.metadata.create_all(bind=engine)
+
 app = FastAPI(
     title="CodeScale Research Radar API",
     description="Signal vs Noise classification API for engineering teams",
@@ -17,6 +24,9 @@ app.add_middleware(
     allow_methods=["*"],
     allow_headers=["*"],
 )
+
+# Include API routers
+app.include_router(items.router, prefix="/api")
 
 
 @app.get("/")

--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -4,7 +4,7 @@ To be implemented in issue #4.
 """
 
 from sqlalchemy import Column, Integer, String, Text, CheckConstraint
-from sqlalchemy.ext.declarative import declarative_base
+from sqlalchemy.orm import declarative_base
 
 Base = declarative_base()
 

--- a/backend/app/routers/__init__.py
+++ b/backend/app/routers/__init__.py
@@ -1,0 +1,1 @@
+"""API routers package."""

--- a/backend/app/routers/items.py
+++ b/backend/app/routers/items.py
@@ -1,0 +1,136 @@
+"""CRUD API endpoints for trend items."""
+
+from typing import List
+from fastapi import APIRouter, Depends, HTTPException, status
+from sqlalchemy.orm import Session
+
+from ..database import get_db
+from ..models import Trend, Base
+from ..schemas import (
+    TrendCreate,
+    TrendUpdate,
+    TrendResponse,
+    TrendListResponse,
+)
+
+router = APIRouter(prefix="/items", tags=["items"])
+
+
+@router.get("", response_model=TrendListResponse)
+async def get_items(
+    skip: int = 0,
+    limit: int = 100,
+    db: Session = Depends(get_db)
+):
+    """Get all trend items with pagination.
+
+    Args:
+        skip: Number of items to skip (default: 0)
+        limit: Maximum number of items to return (default: 100)
+        db: Database session
+
+    Returns:
+        List of trend items with total count
+    """
+    items = db.query(Trend).offset(skip).limit(limit).all()
+    total = db.query(Trend).count()
+    return TrendListResponse(items=items, total=total)
+
+
+@router.get("/{item_id}", response_model=TrendResponse)
+async def get_item(item_id: int, db: Session = Depends(get_db)):
+    """Get a single trend item by ID.
+
+    Args:
+        item_id: The ID of the item to retrieve
+        db: Database session
+
+    Returns:
+        The trend item
+
+    Raises:
+        HTTPException: If item not found
+    """
+    item = db.query(Trend).filter(Trend.id == item_id).first()
+    if item is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=f"Item with id {item_id} not found"
+        )
+    return item
+
+
+@router.post("", response_model=TrendResponse, status_code=status.HTTP_201_CREATED)
+async def create_item(item: TrendCreate, db: Session = Depends(get_db)):
+    """Create a new trend item.
+
+    Args:
+        item: The trend data to create
+        db: Database session
+
+    Returns:
+        The created trend item
+    """
+    db_item = Trend(**item.model_dump())
+    db.add(db_item)
+    db.commit()
+    db.refresh(db_item)
+    return db_item
+
+
+@router.put("/{item_id}", response_model=TrendResponse)
+async def update_item(
+    item_id: int,
+    item: TrendUpdate,
+    db: Session = Depends(get_db)
+):
+    """Update an existing trend item.
+
+    Args:
+        item_id: The ID of the item to update
+        item: The updated trend data
+        db: Database session
+
+    Returns:
+        The updated trend item
+
+    Raises:
+        HTTPException: If item not found
+    """
+    db_item = db.query(Trend).filter(Trend.id == item_id).first()
+    if db_item is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=f"Item with id {item_id} not found"
+        )
+
+    update_data = item.model_dump(exclude_unset=True)
+    for field, value in update_data.items():
+        setattr(db_item, field, value)
+
+    db.commit()
+    db.refresh(db_item)
+    return db_item
+
+
+@router.delete("/{item_id}", status_code=status.HTTP_204_NO_CONTENT)
+async def delete_item(item_id: int, db: Session = Depends(get_db)):
+    """Delete a trend item.
+
+    Args:
+        item_id: The ID of the item to delete
+        db: Database session
+
+    Raises:
+        HTTPException: If item not found
+    """
+    db_item = db.query(Trend).filter(Trend.id == item_id).first()
+    if db_item is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=f"Item with id {item_id} not found"
+        )
+
+    db.delete(db_item)
+    db.commit()
+    return None

--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -1,0 +1,83 @@
+"""Pydantic schemas for request/response validation."""
+
+from typing import Optional, List
+from pydantic import BaseModel, Field
+
+
+class TrendBase(BaseModel):
+    """Base schema for trend data."""
+
+    radar_date: str = Field(..., description="Date of the radar analysis")
+    focus_area: str = Field(..., description="Area of focus for the tool")
+    tool_name: str = Field(..., description="Name of the tool being classified")
+    classification: str = Field(
+        ...,
+        pattern="^(signal|noise)$",
+        description="Classification: 'signal' or 'noise'"
+    )
+    confidence_score: int = Field(
+        ...,
+        ge=0,
+        le=100,
+        description="Confidence score (0-100)"
+    )
+    technical_insight: str = Field(..., description="Technical analysis insight")
+    signal_evidence: Optional[str] = Field(
+        None,
+        description="JSON string of signal evidence"
+    )
+    noise_indicators: Optional[str] = Field(
+        None,
+        description="JSON string of noise indicators"
+    )
+    architectural_verdict: int = Field(
+        ...,
+        ge=1,
+        le=5,
+        description="Architectural verdict score (1-5)"
+    )
+    timestamp: str = Field(..., description="Timestamp of the analysis")
+
+
+class TrendCreate(TrendBase):
+    """Schema for creating a new trend."""
+
+    pass
+
+
+class TrendUpdate(BaseModel):
+    """Schema for updating an existing trend."""
+
+    radar_date: Optional[str] = None
+    focus_area: Optional[str] = None
+    tool_name: Optional[str] = None
+    classification: Optional[str] = Field(
+        None,
+        pattern="^(signal|noise)$"
+    )
+    confidence_score: Optional[int] = Field(None, ge=0, le=100)
+    technical_insight: Optional[str] = None
+    signal_evidence: Optional[str] = None
+    noise_indicators: Optional[str] = None
+    architectural_verdict: Optional[int] = Field(None, ge=1, le=5)
+    timestamp: Optional[str] = None
+
+
+class TrendResponse(TrendBase):
+    """Schema for trend response including ID."""
+
+    id: int
+    model_config = {"from_attributes": True}
+
+
+class TrendListResponse(BaseModel):
+    """Schema for list of trends response."""
+
+    items: List[TrendResponse]
+    total: int
+
+
+class ErrorResponse(BaseModel):
+    """Schema for error responses."""
+
+    detail: str

--- a/backend/tests/test_items.py
+++ b/backend/tests/test_items.py
@@ -1,0 +1,212 @@
+"""Tests for the items CRUD API endpoints."""
+
+import pytest
+from fastapi.testclient import TestClient
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+from sqlalchemy.pool import StaticPool
+
+from app.main import app
+from app.database import get_db
+from app.models import Base
+
+
+# Create in-memory SQLite database for testing
+SQLALCHEMY_DATABASE_URL = "sqlite:///:memory:"
+engine = create_engine(
+    SQLALCHEMY_DATABASE_URL,
+    connect_args={"check_same_thread": False},
+    poolclass=StaticPool,
+)
+TestingSessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
+
+
+def override_get_db():
+    """Override database dependency for testing."""
+    db = TestingSessionLocal()
+    try:
+        yield db
+    finally:
+        db.close()
+
+
+@pytest.fixture(scope="function")
+def client():
+    """Create a test client with fresh database for each test."""
+    # Create tables
+    Base.metadata.create_all(bind=engine)
+
+    # Override the dependency
+    app.dependency_overrides[get_db] = override_get_db
+
+    with TestClient(app) as test_client:
+        yield test_client
+
+    # Drop tables after test
+    Base.metadata.drop_all(bind=engine)
+    app.dependency_overrides.clear()
+
+
+@pytest.fixture
+def sample_item():
+    """Return sample item data for testing."""
+    return {
+        "radar_date": "2026-02-17",
+        "focus_area": "AI/ML",
+        "tool_name": "LiteLLM",
+        "classification": "signal",
+        "confidence_score": 85,
+        "technical_insight": "Strong adoption in enterprise settings",
+        "signal_evidence": '["high github stars", "active community"]',
+        "noise_indicators": None,
+        "architectural_verdict": 4,
+        "timestamp": "2026-02-17T10:00:00Z"
+    }
+
+
+def test_get_items_empty(client):
+    """Test getting items when database is empty."""
+    response = client.get("/api/items")
+    assert response.status_code == 200
+    data = response.json()
+    assert data["items"] == []
+    assert data["total"] == 0
+
+
+def test_create_item(client, sample_item):
+    """Test creating a new item."""
+    response = client.post("/api/items", json=sample_item)
+    assert response.status_code == 201
+    data = response.json()
+    assert data["id"] is not None
+    assert data["tool_name"] == sample_item["tool_name"]
+    assert data["classification"] == sample_item["classification"]
+
+
+def test_get_items_after_create(client, sample_item):
+    """Test getting items after creating one."""
+    # Create an item
+    client.post("/api/items", json=sample_item)
+
+    # Get all items
+    response = client.get("/api/items")
+    assert response.status_code == 200
+    data = response.json()
+    assert data["total"] == 1
+    assert len(data["items"]) == 1
+    assert data["items"][0]["tool_name"] == sample_item["tool_name"]
+
+
+def test_get_item_by_id(client, sample_item):
+    """Test getting a single item by ID."""
+    # Create an item
+    create_response = client.post("/api/items", json=sample_item)
+    item_id = create_response.json()["id"]
+
+    # Get the item
+    response = client.get(f"/api/items/{item_id}")
+    assert response.status_code == 200
+    data = response.json()
+    assert data["id"] == item_id
+    assert data["tool_name"] == sample_item["tool_name"]
+
+
+def test_get_item_not_found(client):
+    """Test getting a non-existent item."""
+    response = client.get("/api/items/999")
+    assert response.status_code == 404
+    assert "not found" in response.json()["detail"].lower()
+
+
+def test_update_item(client, sample_item):
+    """Test updating an existing item."""
+    # Create an item
+    create_response = client.post("/api/items", json=sample_item)
+    item_id = create_response.json()["id"]
+
+    # Update the item
+    update_data = {
+        "classification": "noise",
+        "confidence_score": 30
+    }
+    response = client.put(f"/api/items/{item_id}", json=update_data)
+    assert response.status_code == 200
+    data = response.json()
+    assert data["classification"] == "noise"
+    assert data["confidence_score"] == 30
+    # Unchanged fields should remain
+    assert data["tool_name"] == sample_item["tool_name"]
+
+
+def test_update_item_not_found(client):
+    """Test updating a non-existent item."""
+    update_data = {"classification": "noise"}
+    response = client.put("/api/items/999", json=update_data)
+    assert response.status_code == 404
+    assert "not found" in response.json()["detail"].lower()
+
+
+def test_delete_item(client, sample_item):
+    """Test deleting an item."""
+    # Create an item
+    create_response = client.post("/api/items", json=sample_item)
+    item_id = create_response.json()["id"]
+
+    # Delete the item
+    response = client.delete(f"/api/items/{item_id}")
+    assert response.status_code == 204
+
+    # Verify item is deleted
+    get_response = client.get(f"/api/items/{item_id}")
+    assert get_response.status_code == 404
+
+
+def test_delete_item_not_found(client):
+    """Test deleting a non-existent item."""
+    response = client.delete("/api/items/999")
+    assert response.status_code == 404
+    assert "not found" in response.json()["detail"].lower()
+
+
+def test_pagination(client, sample_item):
+    """Test pagination with skip and limit."""
+    # Create multiple items
+    for i in range(5):
+        item = sample_item.copy()
+        item["tool_name"] = f"Tool_{i}"
+        client.post("/api/items", json=item)
+
+    # Test skip
+    response = client.get("/api/items?skip=2")
+    assert response.status_code == 200
+    data = response.json()
+    assert len(data["items"]) == 3
+    assert data["total"] == 5
+
+    # Test limit
+    response = client.get("/api/items?limit=2")
+    assert response.status_code == 200
+    data = response.json()
+    assert len(data["items"]) == 2
+    assert data["total"] == 5
+
+
+def test_create_item_invalid_classification(client, sample_item):
+    """Test creating item with invalid classification."""
+    sample_item["classification"] = "invalid"
+    response = client.post("/api/items", json=sample_item)
+    assert response.status_code == 422  # Validation error
+
+
+def test_create_item_invalid_confidence_score(client, sample_item):
+    """Test creating item with invalid confidence score."""
+    sample_item["confidence_score"] = 150  # Out of range
+    response = client.post("/api/items", json=sample_item)
+    assert response.status_code == 422  # Validation error
+
+
+def test_create_item_invalid_architectural_verdict(client, sample_item):
+    """Test creating item with invalid architectural verdict."""
+    sample_item["architectural_verdict"] = 10  # Out of range (1-5)
+    response = client.post("/api/items", json=sample_item)
+    assert response.status_code == 422  # Validation error


### PR DESCRIPTION
## Summary
- Implement RESTful CRUD API endpoints for trend items
- Add GET /api/items with pagination support (skip/limit parameters)
- Add POST /api/items for creating new trend entries
- Add PUT /api/items/{id} for updating existing trends
- Add DELETE /api/items/{id} for removing trends
- Add Pydantic schemas for request/response validation with proper error handling

## Testing Done
- [x] `pytest` passes (15 tests)
- [x] All CRUD endpoints return correct responses
- [x] Error handling works (404 for not found items)
- [x] Validation works (422 for invalid data)

## Issue
Closes #4